### PR TITLE
[Feat/30/get reservations] 사찰의 예약 정보 조회 - temple service 연결 (feign client), 헤더 추가 어노테이션 구현

### DIFF
--- a/com.templlo.service.reservation/src/main/java/com/templlo/service/reservation/ReservationApplication.java
+++ b/com.templlo.service.reservation/src/main/java/com/templlo/service/reservation/ReservationApplication.java
@@ -2,7 +2,9 @@ package com.templlo.service.reservation;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
+@EnableFeignClients
 @SpringBootApplication
 public class ReservationApplication {
 

--- a/com.templlo.service.reservation/src/main/java/com/templlo/service/reservation/domain/reservation/client/TempleClient.java
+++ b/com.templlo.service.reservation/src/main/java/com/templlo/service/reservation/domain/reservation/client/TempleClient.java
@@ -2,6 +2,7 @@ package com.templlo.service.reservation.domain.reservation.client;
 
 import com.templlo.service.reservation.domain.reservation.client.model.response.GetProgramsByTempleRes;
 import com.templlo.service.reservation.domain.reservation.client.model.response.ProgramServiceWrapperRes;
+import com.templlo.service.reservation.global.feign.AuthHeader;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -12,6 +13,8 @@ import java.util.UUID;
 
 @FeignClient("program-service")
 public interface TempleClient {
+
+    @AuthHeader
     @GetMapping("/api/programs/temples/{templeId}")
     ProgramServiceWrapperRes<List<GetProgramsByTempleRes>> getProgramsByTemple(@PathVariable(name = "templeId") UUID templeId);
 }

--- a/com.templlo.service.reservation/src/main/java/com/templlo/service/reservation/domain/reservation/client/TempleClient.java
+++ b/com.templlo.service.reservation/src/main/java/com/templlo/service/reservation/domain/reservation/client/TempleClient.java
@@ -1,0 +1,17 @@
+package com.templlo.service.reservation.domain.reservation.client;
+
+import com.templlo.service.reservation.domain.reservation.client.model.response.GetProgramsByTempleRes;
+import com.templlo.service.reservation.domain.reservation.client.model.response.ProgramServiceWrapperRes;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+
+import java.util.List;
+import java.util.UUID;
+
+@FeignClient("program-service")
+public interface TempleClient {
+    @GetMapping("/api/programs/temples/{templeId}")
+    ProgramServiceWrapperRes<List<GetProgramsByTempleRes>> getProgramsByTemple(@PathVariable(name = "templeId") UUID templeId);
+}

--- a/com.templlo.service.reservation/src/main/java/com/templlo/service/reservation/domain/reservation/client/model/response/GetProgramsByTempleRes.java
+++ b/com.templlo.service.reservation/src/main/java/com/templlo/service/reservation/domain/reservation/client/model/response/GetProgramsByTempleRes.java
@@ -1,0 +1,14 @@
+package com.templlo.service.reservation.domain.reservation.client.model.response;
+
+import java.util.List;
+import java.util.UUID;
+
+public record GetProgramsByTempleRes(
+    ProgramType type,
+    UUID programId,
+    Integer programFee
+) {
+    public static List<UUID> getProgramIds(List<GetProgramsByTempleRes> dtos) {
+        return dtos.stream().map(GetProgramsByTempleRes::programId).toList();
+    }
+}

--- a/com.templlo.service.reservation/src/main/java/com/templlo/service/reservation/domain/reservation/client/model/response/ProgramServiceWrapperRes.java
+++ b/com.templlo.service.reservation/src/main/java/com/templlo/service/reservation/domain/reservation/client/model/response/ProgramServiceWrapperRes.java
@@ -1,0 +1,10 @@
+package com.templlo.service.reservation.domain.reservation.client.model.response;
+
+public record ProgramServiceWrapperRes<T> (
+        String status,
+        String code,
+        String message,
+        T data
+) {
+
+}

--- a/com.templlo.service.reservation/src/main/java/com/templlo/service/reservation/domain/reservation/client/model/response/ProgramType.java
+++ b/com.templlo.service.reservation/src/main/java/com/templlo/service/reservation/domain/reservation/client/model/response/ProgramType.java
@@ -1,0 +1,6 @@
+package com.templlo.service.reservation.domain.reservation.client.model.response;
+
+public enum ProgramType {
+    TEMPLE_STAY,
+    BLIND_DATE
+}

--- a/com.templlo.service.reservation/src/main/java/com/templlo/service/reservation/domain/reservation/controller/ReservationQueryController.java
+++ b/com.templlo.service.reservation/src/main/java/com/templlo/service/reservation/domain/reservation/controller/ReservationQueryController.java
@@ -43,12 +43,10 @@ public class ReservationQueryController {
     @GetMapping("/temples/{templeId}/reservations")
     public ResponseEntity<ApiResponse<TempleReservationListWrapperRes>> getReservationsByTemple(
             @PathVariable(name = "templeId") UUID templeId,
-            Pageable pageable,
-            @RequestParam(name = "tempProgramId1") UUID tempProgramId1,
-            @RequestParam(name = "tempProgramId2") UUID tempProgramId2
+            Pageable pageable
     ) {
         Pageable pageRequest = PageUtil.getCheckedPageable(pageable);
-        TempleReservationListWrapperRes responseDto = reservationQueryService.getReservationsByTemple(templeId, pageRequest, tempProgramId1, tempProgramId2);
+        TempleReservationListWrapperRes responseDto = reservationQueryService.getReservationsByTemple(templeId, pageRequest);
         return ResponseEntity.ok().body(
                 ApiResponse.of(ReservationStatusCode.GET_RESERVATIONS_OF_TEMPLE_SUCCESS, responseDto));
     }

--- a/com.templlo.service.reservation/src/main/java/com/templlo/service/reservation/domain/reservation/controller/client/TempleClient.java
+++ b/com.templlo.service.reservation/src/main/java/com/templlo/service/reservation/domain/reservation/controller/client/TempleClient.java
@@ -1,4 +1,0 @@
-package com.templlo.service.reservation.domain.reservation.controller.client;
-
-public interface TempleClient {
-}

--- a/com.templlo.service.reservation/src/main/java/com/templlo/service/reservation/global/config/ConsumerApplicationKafkaConfig.java
+++ b/com.templlo.service.reservation/src/main/java/com/templlo/service/reservation/global/config/ConsumerApplicationKafkaConfig.java
@@ -6,7 +6,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
-import org.springframework.kafka.config.KafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 
@@ -24,6 +23,7 @@ public class ConsumerApplicationKafkaConfig {
         configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
         configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+//        configProps.put(ConsumerConfig.RECONNECT_BACKOFF_MAX_MS_CONFIG, 10000); // reconnect 간격 기본값 1000 -> 5000 5초 -> 10초
         return new DefaultKafkaConsumerFactory<>(configProps);
     }
 

--- a/com.templlo.service.reservation/src/main/java/com/templlo/service/reservation/global/feign/AuthHeader.java
+++ b/com.templlo.service.reservation/src/main/java/com/templlo/service/reservation/global/feign/AuthHeader.java
@@ -1,0 +1,11 @@
+package com.templlo.service.reservation.global.feign;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthHeader {
+}

--- a/com.templlo.service.reservation/src/main/java/com/templlo/service/reservation/global/feign/FeignAuthHeaderInterceptor.java
+++ b/com.templlo.service.reservation/src/main/java/com/templlo/service/reservation/global/feign/FeignAuthHeaderInterceptor.java
@@ -1,0 +1,38 @@
+package com.templlo.service.reservation.global.feign;
+
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import java.lang.reflect.Method;
+
+import static com.templlo.service.reservation.global.GlobalConst.*;
+
+@Component
+public class FeignAuthHeaderInterceptor implements RequestInterceptor {
+    @Override
+    public void apply(RequestTemplate requestTemplate) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null) {
+            return;
+        }
+
+        Method method = requestTemplate.methodMetadata().method();
+        if(method.isAnnotationPresent(AuthHeader.class)) {
+            setAuthHeaders(requestTemplate, authentication);
+        }
+    }
+
+    private void setAuthHeaders(RequestTemplate requestTemplate, Authentication authentication) {
+        requestTemplate.header(HEADER_NAME_USER_ID, authentication.getPrincipal().toString());
+        requestTemplate.header(HEADER_NAME_USER_ROLE, getRole(authentication));
+        requestTemplate.header(HEADER_NAME_USED_AUTH_TOKEN, authentication.getCredentials().toString());
+    }
+
+    private String getRole(Authentication authentication) {
+        GrantedAuthority grantedAuthority = authentication.getAuthorities().iterator().next();
+        return grantedAuthority.getAuthority();
+    }
+}

--- a/com.templlo.service.reservation/src/main/resources/http/reservation/ReservationCreate.http
+++ b/com.templlo.service.reservation/src/main/resources/http/reservation/ReservationCreate.http
@@ -1,4 +1,5 @@
-@accessToken = eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE3MzY1MDEyMTEsImV4cCI6MTczNjUwMzAxMSwibG9naW5JZCI6InRlc3QxMjM0Iiwicm9sZSI6Ik1FTUJFUiIsInR5cGUiOiJhY2Nlc3MifQ.O83AJZG2qlUsUBowQ1-OZAjKdMJf6NM9Mg4gSSNrdz0
+@accessToken = eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE3MzY1ODI1ODIsImV4cCI6MTczNjU4NDM4MiwibG9naW5JZCI6InRlc3QxMjM0Iiwicm9sZSI6Ik1FTUJFUiIsInR5cGUiOiJhY2Nlc3MifQ.HT-KZcMMyeAsqYpJ9jvDqk18CFIbAsIsXkOEfUw0SzI
+@accessTokenTemple = eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE3MzY1ODMzMDgsImV4cCI6MTczNjU4NTEwOCwibG9naW5JZCI6ImFkbWluMTAwMCIsInJvbGUiOiJURU1QTEVfQURNSU4iLCJ0eXBlIjoiYWNjZXNzIn0.-4k5vrjKec7RDZADPAwJ-_dGk1m9Ze8mM5hqv-zq5Vw
 @promotionId = 20455a70-7c75-46c0-a87d-65baeb19b20e
 
 # CreateReservation controller api list
@@ -15,7 +16,7 @@ Authorization: Bearer {{accessToken}}
   "programDate": "2025-01-01",
   "couponUsedType": "USED",
   "couponId": "b7e670f9-ae9e-41ae-8f48-9750e481813e",
-  "name": "삐까2",
+  "name": "삐까",
   "phoneNumber": "010-333-7777",
   "gender": "FEMALE",
   "paymentType": "NO_PAY",

--- a/com.templlo.service.reservation/src/main/resources/http/reservation/ReservationQuery.http
+++ b/com.templlo.service.reservation/src/main/resources/http/reservation/ReservationQuery.http
@@ -5,7 +5,8 @@
 @tempProgramId1 = 2560006b-0962-4950-8ea7-c6babddffce3
 @tempProgramId2 = 2560006b-0962-4950-8ea7-c6babddffce3
 
-@accessToken = eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE3MzY1MDEyMTEsImV4cCI6MTczNjUwMzAxMSwibG9naW5JZCI6InRlc3QxMjM0Iiwicm9sZSI6Ik1FTUJFUiIsInR5cGUiOiJhY2Nlc3MifQ.O83AJZG2qlUsUBowQ1-OZAjKdMJf6NM9Mg4gSSNrdz0
+@accessToken = eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE3MzY1ODI1ODIsImV4cCI6MTczNjU4NDM4MiwibG9naW5JZCI6InRlc3QxMjM0Iiwicm9sZSI6Ik1FTUJFUiIsInR5cGUiOiJhY2Nlc3MifQ.HT-KZcMMyeAsqYpJ9jvDqk18CFIbAsIsXkOEfUw0SzI
+@accessTokenTemple = eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE3MzY1ODMzMDgsImV4cCI6MTczNjU4NTEwOCwibG9naW5JZCI6ImFkbWluMTAwMCIsInJvbGUiOiJURU1QTEVfQURNSU4iLCJ0eXBlIjoiYWNjZXNzIn0.-4k5vrjKec7RDZADPAwJ-_dGk1m9Ze8mM5hqv-zq5Vw
 @promotionId = 20455a70-7c75-46c0-a87d-65baeb19b20e
 
 
@@ -17,13 +18,20 @@ X-Token: token value something
 
 
 ### getReservationsByUser
-GET http://localhost:19091/api/reservations/users/{{userId}}/reservations?page=-1&size=20&sort=created_at
+GET http://localhost:19091/api/users/{{userId}}/reservations?page=-1&size=20&sort=created_at
 Authorization: Bearer {{accessToken}}
 
 
 
 ### getReservationsByTemple
-GET http://localhost:19091/api/reservations/temples/2560006b-0962-4950-8ea7-c6babddffce0/reservations?page=0&size=&
+GET http://localhost:19091/api/temples/2560006b-0962-4950-8ea7-c6babddffce0/reservations?page=0&size=&
     sort=updatedAt&
     tempProgramId1={{tempProgramId1}}&tempProgramId2={{tempProgramId2}}
-Authorization: Bearer {{accessToken}}
+Authorization: Bearer {{accessTokenTemple}}
+
+### getReservationsByTemple : 19040
+GET http://localhost:19040/api/temples/2560006b-0962-4950-8ea7-c6babddffce0/reservations?page=0&size=&
+    sort=updatedAt
+X-Login-Id: tempUserId77
+X-User-Role: TEMPLE_ADMIN
+X-Token: token value something

--- a/gateway/src/main/resources/application.yaml
+++ b/gateway/src/main/resources/application.yaml
@@ -9,10 +9,17 @@ spring:
   cloud:
     gateway:
       routes:
+        - id: reservation-service-detail
+          uri: lb://reservation-service
+          predicates:
+            - Path=/api/users/*/reservations, /api/temples/*/reservations
+            - Method=GET
+          order: 1
         - id: user-service
           uri: lb://user-service
           predicates:
             - Path=/api/auth/**, /api/users/**
+          order: 10
         - id: review-service
           uri: lb://review-service
           predicates:
@@ -21,6 +28,7 @@ spring:
           uri: lb://temple-service
           predicates:
             - Path=/api/temples/**
+          order: 10
         - id: program-service
           uri: lb://program-service
           predicates:
@@ -28,7 +36,7 @@ spring:
         - id: reservation-service
           uri: lb://reservation-service
           predicates:
-            - Path=/api/reservations/**
+            - Path=/api/reservations/**, /api/users
         - id: promotion-service
           uri: lb://promotion-service
           predicates:

--- a/gateway/src/main/resources/application.yaml
+++ b/gateway/src/main/resources/application.yaml
@@ -36,7 +36,7 @@ spring:
         - id: reservation-service
           uri: lb://reservation-service
           predicates:
-            - Path=/api/reservations/**, /api/users
+            - Path=/api/reservations/**
         - id: promotion-service
           uri: lb://promotion-service
           predicates:


### PR DESCRIPTION
#️⃣ **Issue Number**
- #30 



---

## 📝 **요약 (Summary)**
- 사찰의 예약 정보 조회 - temple service 연결 (feign client)
- @AuthHeader 어노테이션 구현
  feign client 로 요청을 보낼 시에 요청 메서드에 @AuthHeader 어노테이션을 달면,
  현재 시큐리티에 저장된 정보를 가져와 요청에 인증 정보 헤더 3개를 추가해줌
   - 참고 파일들 : FeignAuthHeaderInterceptor.java, AuthHeader.java
- gateway 라우팅 경로 추가
  아래 예약 조회 api 경로들은 예외적으로 reservation 서비스로 라우팅 되도록 추가 및 우선순위 설정
   - /api/users/{userId}/reservations
   - /api/tempes/{templeId}/reservations
   
---

## **PR 타입**
- 아래에서 해당하는 PR 유형을 선택하세요(체크박스를 `x`로 표시).
    - [x] 새로운 기능 추가

---

## 💬 **공유사항 (to 리뷰어)**
elk 실행에 문제가 있어서 사찰 서비스 실행을 못하고 있습니다.
사찰 예약 목록 조회의 feign client 요청이 잘 가는 건 확인했는데 
temple 쪽에서 받아서 잘 동작하는지 그 뒷부분은 아직 실행 테스트를 못해봤습니다,,


## ✅ **PR Checklist**
- [ ] 자유롭게 추가해서 사용해 주세요.
---

