### PR TITLE
[Refactor/79/distribute lock aop] AOP 활용하여 트랜잭션 범위 설정을 포함한 분산락 적용 로직 모듈화

### DIFF
--- a/com.templlo.service.program/src/main/java/com/templlo/service/program/config/KafkaConfig.java
+++ b/com.templlo.service.program/src/main/java/com/templlo/service/program/config/KafkaConfig.java
@@ -8,7 +8,12 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.config.KafkaListenerContainerFactory;
 import org.springframework.kafka.core.*;
+import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
+import org.springframework.kafka.support.converter.BatchMessagingMessageConverter;
+import org.springframework.kafka.support.converter.JsonMessageConverter;
+import org.springframework.kafka.support.converter.StringJsonMessageConverter;
 import org.springframework.kafka.support.serializer.JsonSerializer;
 
 import java.util.HashMap;
@@ -32,6 +37,8 @@ public class KafkaConfig {
     public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
         ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(consumerFactory());
+        factory.setRecordMessageConverter(new JsonMessageConverter());
+        factory.setBatchMessageConverter(new BatchMessagingMessageConverter(new JsonMessageConverter()));
         return factory;
     }
 

--- a/com.templlo.service.program/src/main/java/com/templlo/service/program/exception/ProgramStatusCode.java
+++ b/com.templlo.service.program/src/main/java/com/templlo/service/program/exception/ProgramStatusCode.java
@@ -21,8 +21,8 @@ public enum ProgramStatusCode implements StatusCode {
     BLIND_DATE_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 블라인드 소개팅의 정보를 찾을 수 없습니다."),
 
     // 검증
-    BAD_REQUEST_BLIND_INFO_ADDITIONAL_RESERVATION_DATE(HttpStatus.BAD_REQUEST, "추가 예약 시작 및 종료 날짜는 기존 날짜 이후로 입력 가능합니다.")
-    ;
+    BAD_REQUEST_BLIND_INFO_ADDITIONAL_RESERVATION_DATE(HttpStatus.BAD_REQUEST, "추가 예약 시작 및 종료 날짜는 기존 날짜 이후로 입력 가능합니다."),
+    BAD_REQUEST_WITHOUT_PROGRAM_ID(HttpStatus.BAD_REQUEST, "프로그램 ID 값이 비어있습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/com.templlo.service.program/src/main/java/com/templlo/service/program/global/aop/distributed_lock/AopTransaction.java
+++ b/com.templlo.service.program/src/main/java/com/templlo/service/program/global/aop/distributed_lock/AopTransaction.java
@@ -1,0 +1,15 @@
+package com.templlo.service.program.global.aop.distributed_lock;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class AopTransaction {
+
+    @Transactional(propagation= Propagation.REQUIRES_NEW)
+    public Object proceedWithTransaction(ProceedingJoinPoint joinPoint) throws Throwable {
+        return joinPoint.proceed();
+    }
+}

--- a/com.templlo.service.program/src/main/java/com/templlo/service/program/global/aop/distributed_lock/CustomSpELParser.java
+++ b/com.templlo.service.program/src/main/java/com/templlo/service/program/global/aop/distributed_lock/CustomSpELParser.java
@@ -1,4 +1,4 @@
-package com.templlo.service.program.validation;
+package com.templlo.service.program.global.aop.distributed_lock;
 
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.reflect.MethodSignature;

--- a/com.templlo.service.program/src/main/java/com/templlo/service/program/global/aop/distributed_lock/DistributedLock.java
+++ b/com.templlo.service.program/src/main/java/com/templlo/service/program/global/aop/distributed_lock/DistributedLock.java
@@ -10,20 +10,22 @@ import java.lang.annotation.Target;
 public @interface DistributedLock {
     /**
      * key 유형
-     * @return
      */
     DistributedLockKey keyType();
 
     /**
+     * 구체적인 식별자를 표현하는 Spring Expression Language
+     */
+    String idSpEL() default "";
+
+    /**
      * 락 획득을 위해 기다릴 최대 시간
-     * @return
      */
     long maxWaitTime() default 5L;
 
     /**
      * 락을 소유하고 있을 최대 시간
      * : 이 시간이 지나면 자동으로 락을 해제(반납)한다
-     * @return
      */
     long maxLeaseTime() default 3L;
 }

--- a/com.templlo.service.program/src/main/java/com/templlo/service/program/global/aop/distributed_lock/DistributedLock.java
+++ b/com.templlo.service.program/src/main/java/com/templlo/service/program/global/aop/distributed_lock/DistributedLock.java
@@ -1,0 +1,29 @@
+package com.templlo.service.program.global.aop.distributed_lock;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+    /**
+     * key 유형
+     * @return
+     */
+    DistributedLockKey keyType();
+
+    /**
+     * 락 획득을 위해 기다릴 최대 시간
+     * @return
+     */
+    long maxWaitTime() default 5L;
+
+    /**
+     * 락을 소유하고 있을 최대 시간
+     * : 이 시간이 지나면 자동으로 락을 해제(반납)한다
+     * @return
+     */
+    long maxLeaseTime() default 3L;
+}

--- a/com.templlo.service.program/src/main/java/com/templlo/service/program/global/aop/distributed_lock/DistributedLockAop.java
+++ b/com.templlo.service.program/src/main/java/com/templlo/service/program/global/aop/distributed_lock/DistributedLockAop.java
@@ -1,6 +1,5 @@
 package com.templlo.service.program.global.aop.distributed_lock;
 
-import com.templlo.service.program.validation.CustomSpELParser;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;

--- a/com.templlo.service.program/src/main/java/com/templlo/service/program/global/aop/distributed_lock/DistributedLockAop.java
+++ b/com.templlo.service.program/src/main/java/com/templlo/service/program/global/aop/distributed_lock/DistributedLockAop.java
@@ -1,0 +1,86 @@
+package com.templlo.service.program.global.aop.distributed_lock;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.templlo.service.program.exception.ProgramException;
+import com.templlo.service.program.exception.ProgramStatusCode;
+import com.templlo.service.program.kafka.message.reservation.ReservationCreateMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class DistributedLockAop {
+    private static final String LOCK_PREFIX = "lock:";
+
+    private final RedissonClient redissonClient;
+    private final ObjectMapper objectMapper;
+    private final AopTransaction aopTransaction;
+
+    /**
+     * DistributedLock 어노테이션이 달린 메서드의 작업 전/후로 redis 분산락을 적용
+     */
+    @Around("@annotation(com.templlo.service.program.global.aop.distributed_lock.DistributedLock)")
+    public Object lock(final ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        DistributedLock lockAnnotation = signature.getMethod().getAnnotation(DistributedLock.class);
+
+        String key = getKey(joinPoint, lockAnnotation, signature);
+        RLock rLock = redissonClient.getLock(key);
+        try{
+            if (!isAvailable(rLock, lockAnnotation)) {
+                return false;
+            }
+            return aopTransaction.proceedWithTransaction(joinPoint);
+        } finally {
+            rLock.unlock();
+        }
+    }
+
+    /**
+     * 락을 적용할 키 생성
+     */
+    private String getKey(ProceedingJoinPoint joinPoint, DistributedLock lockAnnotation, MethodSignature signature) throws JsonProcessingException {
+        return LOCK_PREFIX + lockAnnotation.keyType() + getProgramId(joinPoint, signature);
+    }
+
+    /**
+     * 락 획득 시도
+     */
+    private boolean isAvailable(RLock rLock, DistributedLock lockAnnotation) throws InterruptedException {
+        return rLock.tryLock(lockAnnotation.maxWaitTime(), lockAnnotation.maxLeaseTime(), TimeUnit.SECONDS);
+    }
+
+    /**
+     * 작업 대상 메서드의 인자로부터 programId 값을 추출
+     */
+    private String getProgramId(ProceedingJoinPoint joinPoint, MethodSignature signature) throws JsonProcessingException {
+        Object[] args = joinPoint.getArgs();
+        String[] parameterNames = signature.getParameterNames();
+        Class[] parameterTypes = signature.getParameterTypes();
+
+        String programId = "";
+        for (int i=0; i<args.length; i++){
+            if (parameterNames[i].equals("reservationCreatedMessage") && parameterTypes[i].equals(String.class)){
+                ReservationCreateMessage message = objectMapper.readValue(args[i].toString(), ReservationCreateMessage.class);
+                programId = message.programId().toString();
+            }
+        }
+
+        if(programId.isBlank()) {
+            throw new ProgramException(ProgramStatusCode.BAD_REQUEST_WITHOUT_PROGRAM_ID);
+        }
+        return programId;
+    }
+}

--- a/com.templlo.service.program/src/main/java/com/templlo/service/program/global/aop/distributed_lock/DistributedLockKey.java
+++ b/com.templlo.service.program/src/main/java/com/templlo/service/program/global/aop/distributed_lock/DistributedLockKey.java
@@ -1,0 +1,11 @@
+package com.templlo.service.program.global.aop.distributed_lock;
+
+public enum DistributedLockKey {
+    TEMPLE_STAY_PROGRAM_CAPACITY_PREFIX("temple-stay:capacity:");
+
+    private final String keyName;
+
+    DistributedLockKey(String keyName) {
+        this.keyName = keyName;
+    }
+}

--- a/com.templlo.service.program/src/main/java/com/templlo/service/program/global/aop/distributed_lock/DistributedLockKey.java
+++ b/com.templlo.service.program/src/main/java/com/templlo/service/program/global/aop/distributed_lock/DistributedLockKey.java
@@ -1,5 +1,8 @@
 package com.templlo.service.program.global.aop.distributed_lock;
 
+import lombok.Getter;
+
+@Getter
 public enum DistributedLockKey {
     TEMPLE_STAY_PROGRAM_CAPACITY_PREFIX("temple-stay:capacity:");
 

--- a/com.templlo.service.program/src/main/java/com/templlo/service/program/validation/CustomSpELParser.java
+++ b/com.templlo.service.program/src/main/java/com/templlo/service/program/validation/CustomSpELParser.java
@@ -1,0 +1,25 @@
+package com.templlo.service.program.validation;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+public class CustomSpELParser {
+
+    public static Object getDynamicValue(String el, ProceedingJoinPoint joinPoint, MethodSignature signature) {
+        Object[] args = joinPoint.getArgs();
+        String[] parameterNames = signature.getParameterNames();
+
+        ExpressionParser parser = new SpelExpressionParser();
+        StandardEvaluationContext context = new StandardEvaluationContext();
+
+        for(int i=0; i<parameterNames.length; i++) {
+            context.setVariable(parameterNames[i], args[i]);
+        }
+
+        return parser.parseExpression(el).getValue(context, Object.class);
+
+    }
+}


### PR DESCRIPTION
#️⃣ **Issue Number**
- 관련된 이슈 번호를 입력하세요: #79 

---

## 📝 **요약 (Summary)**
- AOP : 분산락 적용 로직 모듈화
- 동시성 처리 (dirty read 방지) : 분산락 로직 내에서 트랜잭션 시작&완료 시점이 락 획득&반납 시점 내부에 포함되도록 함
- kafka config 에 json converter 설정 추가 -> consumer 메서드에서 인자로 DTO 바로 받기 가능
- Spring Expression Language 를 파싱하는 모듈 클래스 생성, 적용

## 주요 구현 내용
**`global.aop.distribute_lock` 패키지 내에 관련 파일 모두 모여있습니다~
- `@interface DistributedLock` : 분산락 적용을 의미하는 커스텀 어노테이션
- `class DistributedLockAop` : AOP 주요 로직.
    - 주요 내용 : 분산락 키 정의. 분산락을 획득, 해제. 트랜잭션 범위 설정
- `enum DistributedLockKey` : 분산락 키를 정의하는 enum 클래스
- `AopTransaction` : AOP 에서 타겟 객체 실행 시 트랜잭션을 새로 생성하여 사용하도록 하는 클래스 (트랜잭션 커밋 시점을 제한하기 위함)
- `CustomSpELParser` : SpringEL 표현식을 파싱 클래스. 커스텀 어노테이션에 메서드의 파라미터를 인자로 전달하기 위해 SpringEL 표현식을 파싱하여 파라미터값을 가져오는 데에 사용

### 로직 흐름

- `@DistributedLock` 가 붙은 메서드를 타겟 객체로 인식하여 `DistributedLockAop` 의 `lock()` 로직이 실행됨
- `lock()`
    - 어노테이션 파라미터로 전달받은 SpringEL 표현식으로 분산락에 사용할 키를 생성함
    - 분산락 획득 시도
    - 획득 성공 시 `AopTransaction` 을 활용해 타겟객체 로직을 새 트랜잭션 안에서 실행함
    - 실행이 완료되고 트랜잭션이 종료된 후에 락을 반납함

### 추가적으로 할 일

- 다중 스레드 환경을 구성하여 동시성 문제가 발생하는 테스트코드 작성
- `@DistributedLock` 을 사용했을 때와 사용하지 않았을 때 테스트 결과 데이터 정합성 비교

---

## **PR 타입**
- 아래에서 해당하는 PR 유형을 선택하세요(체크박스를 `x`로 표시).
    - [ ] 새로운 기능 추가
    - [x] 리팩토링, 기능 개선

---

## 💬 **공유사항 (to 리뷰어)**
- 테스트해다 발견했는데
예약 시작 날짜 검증 로직이 의도하신 것과 반대로 동작하고 있는 것 같습니다. 확인 부탁드립니다! (TODO 달아뒀습니다!)

## ✅ **PR Checklist**
- [ ] 자유롭게 추가해서 사용해 주세요.
---

